### PR TITLE
Feature/week3 docker network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+
+services:
+  db:
+    image: postgres:16
+    container_name: sis_postgres
+    restart: always
+    env_file:
+      - .env
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    networks:
+      - sis_network
+
+  app:
+    build: .
+    container_name: sis_app
+    restart: always
+    depends_on:
+      - db
+    environment:
+      DB_HOST: db
+      DB_NAME: student_information
+      DB_USER: zuleyha
+      DB_PASSWORD: zuleyha1
+    ports:
+      - "8080:8080"
+    networks:
+      - sis_network
+
+volumes:
+  postgres_data:
+
+networks:
+  sis_network:
+    driver: bridge
+
+
+   


### PR DESCRIPTION
This pull request implements the inter-container networking configuration for Week 3.

Changes included:
- Created a private Docker bridge network for the system
- Connected application and PostgreSQL containers to the same network
- Enabled database connection using service name instead of localhost or IP
- Ensured proper container communication via Docker Compose

This configuration allows secure and isolated communication between services and follows Docker best practices.

Closes #33