### PR TITLE
Add post-final CD pipeline for Docker image publishing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,28 @@
+name: CD Pipeline
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  docker-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build Docker image
+        run: |
+          docker build -t zuleyha34/sis-project-app:latest .
+
+      - name: Push Docker image
+        run: |
+          docker push zuleyha34/sis-project-app:latest


### PR DESCRIPTION
This PR adds a Continuous Deployment (CD) pipeline as a post-final infrastructure improvement.

The pipeline automatically builds and publishes the Docker image to Docker Hub
when changes are pushed to the main branch.

No application logic was modified.